### PR TITLE
Updated Scala.rx dependency to 0.4.0; updated code accordingly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbt.Keys._
 // Versions
 // -----------------------------------------------------------------------
 val ScalaTagsVersion = "0.6.2"
-val ScalaRxVersion = "0.3.2"
+val ScalaRxVersion = "0.4.0"
 val ScalaJSJQueryVersion = "0.9.1"
 
 // -----------------------------------------------------------------------

--- a/context/js/src/main/scala/com/karasiq/bootstrap/context/JSReactiveBinds.scala
+++ b/context/js/src/main/scala/com/karasiq/bootstrap/context/JSReactiveBinds.scala
@@ -35,7 +35,7 @@ trait JSReactiveBinds extends ReactiveBinds { self: JSRenderingContext with Clas
     def bindWrite(parent: E, property: BindNode[N]): Unit = {
       val elRx = property.value.map(identity)
       var oldElement = property.value.now.render
-      elRx.triggerLater {
+      elRx.triggerLater ({
         val element = oldElement
         if (isElementAvailable(element) && isElementAvailable(element.parentNode)) {
           val newElement = elRx.now.render
@@ -44,7 +44,7 @@ trait JSReactiveBinds extends ReactiveBinds { self: JSRenderingContext with Clas
         } else {
           elRx.kill()
         }
-      }
+      }: Unit)
       parent.appendChild(oldElement)
     }
   }


### PR DESCRIPTION
Since Scala.rx 0.3.2 and Scala.rx 0.4.0 seem to be binary incompatible I was wondering if it would be possible to update scalajs-bootstrap accordingly. Without the update to Scala.rx 0.4.0 I wouldn't be able to use scalajs-bootstrap since some of my other 3rd-party libs depend on Scala.rx 0.4.0 and I could imagine others having similar problems.